### PR TITLE
[Fix] 隐藏nav标签中的navigation阴影

### DIFF
--- a/src/renderer/src/assets/css/index.css
+++ b/src/renderer/src/assets/css/index.css
@@ -135,7 +135,7 @@
         @apply fixed right-0 bottom-0 w-full lg:bottom-5 z-30;
     }
     nav .navigation div {
-        @apply lg:rounded-3xl lg:mx-auto lg:max-w-lg lg:overflow-clip shadow-md;
+        @apply lg:rounded-3xl lg:mx-auto lg:max-w-lg lg:overflow-clip;
     }
 
     

--- a/src/renderer/src/views/Home.vue
+++ b/src/renderer/src/views/Home.vue
@@ -21,7 +21,7 @@
                 </md-fab>
                 <Creator :dialog="dialog" :closeDialog="closeDialog"></Creator>
             </div>
-            <div class="navigation">
+            <div class="navigation overflow-clip">
                 <div>
                     <md-navigation-bar :activeIndex="activeIndex" class="lg:max-w-lg flex mx-auto">
                         <md-navigation-tab


### PR DESCRIPTION
### fix

- 使用overflow-clip隐藏md-navigation-bar的阴影